### PR TITLE
[feat] Support for Embed options

### DIFF
--- a/src/convert-dom-to-markdown.ts
+++ b/src/convert-dom-to-markdown.ts
@@ -99,6 +99,7 @@ const convertTagNode = (
       });
     }
   }
+
   if (isCodeElement(node)) {
     if (node.name === 'div') {
       const marks = getRecursionMarks(node, image, markStyle);
@@ -239,6 +240,9 @@ const getChildNodeClass = (node: Element) => {
     .filter(Boolean);
 };
 
+/**
+ * Build image url with query params
+ */
 const buildImageUrl = (
   node: Element,
   image: { size?: boolean; query?: string },

--- a/test/marks/code.test.ts
+++ b/test/marks/code.test.ts
@@ -1,5 +1,5 @@
 import { HTMLToMarkdownParser } from '../../src/html-to-markdown-parser';
-import { options } from './options';
+import { options } from './mock/options';
 
 describe('Code Block', () => {
   test('should return convert code block', () => {

--- a/test/marks/horizontalRule.test.ts
+++ b/test/marks/horizontalRule.test.ts
@@ -1,5 +1,5 @@
 import { HTMLToMarkdownParser } from '../../src/html-to-markdown-parser';
-import { options } from './options';
+import { options } from './mock/options';
 
 describe('Horizontal Rule', () => {
   test('should return convert hr to ---', () => {

--- a/test/marks/image.test.ts
+++ b/test/marks/image.test.ts
@@ -1,5 +1,5 @@
 import { HTMLToMarkdownParser } from '../../src/html-to-markdown-parser';
-import { options } from './options';
+import { options } from './mock/options';
 
 describe('Image', () => {
   test('should return convert img to image marks', () => {

--- a/test/marks/mock/options.ts
+++ b/test/marks/mock/options.ts
@@ -1,4 +1,4 @@
-import { OptionTypes } from '../../src/options';
+import { OptionTypes } from '../../../src/options';
 
 export const options: OptionTypes = {
   image: {

--- a/test/marks/text.test.ts
+++ b/test/marks/text.test.ts
@@ -1,5 +1,5 @@
 import { HTMLToMarkdownParser } from '../../src/html-to-markdown-parser';
-import { options } from './options';
+import { options } from './mock/options';
 
 describe('Text', () => {
   test('should return convert p to text', () => {


### PR DESCRIPTION
Add support for rich editor Embed options. 

For example.

Twitter 
```html
<blockquote class=\"twitter-tweet\" data-dnt=\"true\" align=\"center\"><p lang=\"ja\" dir=\"ltr\">フルリモート/フルフレックスの求人以外とあるんだな</p>— hiro08 (@hiro08gh) <a href=\"https://twitter.com/hiro08gh/status/1784198836472475821?ref_src=twsrc%5Etfw\">April 27, 2024</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>
```

After converting

```bash
[embed](https://twitter.com/hiro08gh/status/1784198836472475821)

or

[embed-twitter](https://twitter.com/hiro08gh/status/1784198836472475821)
```